### PR TITLE
fix: make_line_from(). Error de calculo en malloc. 

### DIFF
--- a/get_next_line.c
+++ b/get_next_line.c
@@ -57,7 +57,7 @@ char	*make_line_from(char *save)
 		return (NULL);
 	while (save[i] != '\0' && save[i] != '\n')
 		i++;
-	line = ft_calloc(i + 2, sizeof(char));
+	line = ft_calloc(i + (save[i] == '\n') + 1, sizeof(char));
 	i = 0;
 	while (save[i] != '\0' && save[i] != '\n')
 	{


### PR DESCRIPTION
Ahora solo si save contine un '\n' se alojara un byte. 
(save[i] == '\n') Dara 1 si es true o 0 si es falso